### PR TITLE
#13 インフラ構成とシーケンスをGitHub Actions→Cron Triggersに置き換える

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 ```mermaid
 sequenceDiagram
     autonumber
-    participant action as GitHub Actions
+    participant cron as Cron Triggers
     participant worker as Cloudflare Workers
     participant web as ボルダリングジムのWebサイト
     participant db as Cloudflare D1
     participant line as LINE API
 
-    action->>action: 1時間毎にWorkerを起動するようにする
-    action->>worker: Worker起動リクエストを送る
+    cron->>cron: 1時間毎にWorkerを起動するようにする
+    cron->>worker: Worker起動リクエストを送る
     worker->>web: お知らせのURLを3件取得する
     web-->>worker: URL
     worker->>db: URLが登録済であるか検索する
@@ -32,8 +32,8 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-    actions[GitHub Actions] --> worker[Cloudflare Workers]
     subgraph Cloudflare
+        cron[Cron Triggers] --> worker[Cloudflare Workers]
         worker --> db[(Cloudflare D1)]
     end
     subgraph LINE


### PR DESCRIPTION
## やったこと
READMEの設計図を微修正した。

## 確認方法
ブランチ開けばにmermaidがプレビューされる
https://github.com/coniva-bouldering/bouldering-gym-notifier/tree/feature/%2313-fix-sequence-and-infra

## 関連issue
Closes #13