### PR TITLE
#71 add domain restriction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.dev.vars
+
 *.code-workspace

--- a/webhook/src/index.ts
+++ b/webhook/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 type Env = {
   DB: D1Database;
   CHANNEL_ACCESS_TOKEN: string;
+  CHANNEL_SECRET: string;
 };
 
 type WebhookEvent = {
@@ -18,10 +19,32 @@ type WebhookEvent = {
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.post("/api/webhook", async (c) => {
-  const data = await c.req.json();
+const encoder = new TextEncoder();
+const algorithm = { name: "HMAC", hash: "SHA-256" };
 
-  const json = data as {
+const hmac = async (secret: string, body: string) => {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    algorithm,
+    false,
+    ["sign", "verify"]
+  );
+  const signature = await crypto.subtle.sign(algorithm.name, key, encoder.encode(body));
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+};
+
+app.post("/api/webhook", async (c) => {
+  const body = await c.req.json();
+
+  const x_line_signature = c.req.headers.get("x-line-signature");
+  const digest = await hmac(c.env.CHANNEL_SECRET, JSON.stringify(body));
+
+  if (digest !== x_line_signature) {
+    return c.text("Bad Request", 400);
+  }
+
+  const json = body as {
     destination: string;
     events: WebhookEvent[];
   };


### PR DESCRIPTION
### やったこと
- webhookの署名の検証

### ローカルでの動作確認
1. webhookのディレクトリに.dev.varsを作成
1. .dev.varsにCHANNEL_SECRETを追加 (CHANNEL_SECRETはLine Developersで確認)
1. webhookをローカルで起動、トンネリング
1. LINE DevelopersのコンソールにwebhookのURLを追加
```
$ echo 'CHANNEL_SECRET="PUT_YOUR_SECET"' > webhook/.dev.vars
$ cd webhook
$ npm run dev
```

### 参考
- https://www.line-community.me/ja/question/5f210fc6851f74fdb4debc90?answerid=5f33566a401690014f7b5633#post-5f33566a401690014f7b5633