### PR TITLE
10件以上古い記事をDBから削除するcron追加

### DIFF
--- a/notifier/src/d1/postedArticles.ts
+++ b/notifier/src/d1/postedArticles.ts
@@ -18,3 +18,16 @@ export const getAllURL = async (DB: D1Database): Promise<string[]> => {
   const results = await DB.prepare(`select url from posted_articles`).raw<string>();
   return results.flat() || [];
 };
+
+export const deleteOldArticles = async (
+  DB: D1Database,
+  exceptLatestNumber = 10
+): Promise<D1Result<unknown>> => {
+  const info = await DB.prepare(
+    `DELETE FROM posted_articles WHERE url NOT IN (SELECT url FROM posted_articles ORDER BY created_at DESC LIMIT ?);`
+  )
+    .bind(exceptLatestNumber)
+    .run();
+
+  return info;
+};

--- a/notifier/wrangler.toml
+++ b/notifier/wrangler.toml
@@ -3,7 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2022-12-01"
 
 [triggers]
-crons = [ "0 0 * * *" ]
+crons = [ "0 0 * * *", "0 1 * * *" ]
 
 [[ d1_databases ]]
 binding = "DB" # i.e. available in your Worker on env.DB

--- a/notifier/wrangler.toml
+++ b/notifier/wrangler.toml
@@ -3,7 +3,10 @@ main = "src/index.ts"
 compatibility_date = "2022-12-01"
 
 [triggers]
-crons = [ "0 0 * * *", "0 1 * * *" ]
+crons = [ 
+  "0 0 * * *", # send message from BOT
+  "0 1 * * *" # delete old articles from D1
+  ]
 
 [[ d1_databases ]]
 binding = "DB" # i.e. available in your Worker on env.DB


### PR DESCRIPTION
### やったこと
- 古い記事を削除するcron triggerの追加

### ローカルでの動作確認
1. .dev.varsにCHANNEL_ACCESS_TOKENを追加
1. notifierをローカルで起動
1. スクレイピング+投稿 `$curl "http://localhost:PUT_YOUR_PORT/__scheduled?cron=0+0+*+*+*" `
1. 記事の削除 `$curl "http://localhost:PUT_YOUR_PORT/__scheduled?cron=1+0+*+*+*" `

### 参考
- https://developers.cloudflare.com/workers/examples/multiple-cron-triggers/

### Issue
Closes #73 